### PR TITLE
docs: polish presentation section flow

### DIFF
--- a/MACGYVBOT-DECK/index.html
+++ b/MACGYVBOT-DECK/index.html
@@ -583,7 +583,7 @@
           <div class="flow-step"><b>Marker center</b><span>서랍 기준 ArUco marker 중심 좌표 인식</span></div>
           <div class="flow-step"><b>Slot offset</b><span>marker center에서 tool slot center까지의 offset 관리</span></div>
           <div class="flow-step"><b>Place target</b><span>tool center가 slot center에 오도록 목표 pose 계산</span></div>
-          <div class="flow-step hot"><b>Store tool</b><span>safe z, RG2 release, drawer close 순서로 보관</span></div>
+          <div class="flow-step"><b>Store tool</b><span>safe z, RG2 release, drawer close 순서로 보관</span></div>
         </div>
         <figure class="wide-media-shot compact aruco-c2c-shot">
           <img src="assets/perception/aruco_c2c.gif?v=loop" alt="ArUco marker center-to-center placement visualization" />
@@ -677,7 +677,7 @@
           <div class="flow-step"><b>Cancel motion</b><span>현재 MoveIt goal cancel</span></div>
           <div class="flow-step"><b>Keep queue</b><span>suspended step 보존</span></div>
           <div class="flow-step"><b>Recover grasp</b><span>YOLO/depth/PCA 재사용</span></div>
-          <div class="flow-step hot"><b>Resume</b><span>중단 step 재실행</span></div>
+          <div class="flow-step"><b>Resume</b><span>중단 step 재실행</span></div>
         </div>
         <figure class="wide-media-shot compact drop-detection-shot">
           <img src="assets/safety/drop_detection.gif?v=loop" alt="Tool drop detection demonstration" />
@@ -725,7 +725,7 @@
       <div class="impact-combined">
         <div class="metrics impact-metrics">
           <div class="metric"><div class="value">MOVE</div><div class="label">작업자가 보관 장소까지 이동하지 않아도 필요한 공구를 받을 수 있음</div></div>
-          <div class="metric"><div class="value">FIND</div><div class="label">서랍 탐색과 공구 선택을 perception 기반 robot task로 전환</div></div>
+          <div class="metric"><div class="value">FIND</div><div class="label">공구 선택을 perception 기반 robot task로 전환</div></div>
           <div class="metric"><div class="value">RETURN</div><div class="label">사용 후 공구 회수와 제자리 보관까지 하나의 closed loop로 처리</div></div>
           <div class="metric"><div class="value">FLOW</div><div class="label">반복적인 공구 이동은 로봇이 담당하고 작업자는 본 작업에 집중</div></div>
         </div>

--- a/MACGYVBOT-DECK/index.html
+++ b/MACGYVBOT-DECK/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>MacGyvBot Troubleshooting Deck</title>
-  <link rel="stylesheet" href="styles/deck.css?v=20260617-section-flow" />
+  <link rel="stylesheet" href="styles/deck.css?v=20260617-task-table-demo" />
 </head>
 <body>
   <main class="deck" id="deck">
@@ -26,14 +26,14 @@
       <div class="split">
         <div>
           <div class="kicker">Presentation Flow</div>
-          <h2>문제 정의에서 설계, 구현, 검증 순서로 설명합니다</h2>
+          <h2>목차</h2>
         </div>
         <div class="arc-grid intro-stack toc-stack" style="grid-template-columns: 1fr; gap: 10px;">
           <div class="flow-step"><b>1. MacGyvBot이 해결하고자 하는 문제</b><span>공구 요청과 반납 흐름</span></div>
           <div class="flow-step"><b>2. 시스템 디자인</b><span>ROS 2 task architecture</span></div>
           <div class="flow-step"><b>3. 구현</b><span>Command, Task, Perception, Manipulation</span></div>
           <div class="flow-step"><b>4. Safety / Simulation</b><span>recovery와 Isaac Sim 검증</span></div>
-          <div class="flow-step"><b>5. 영향력</b><span>결과와 개선 방향</span></div>
+          <div class="flow-step"><b>5. 평가</b><span>결과와 개선 방향</span></div>
         </div>
       </div>
     </section>
@@ -75,8 +75,8 @@
       <div class="problem-goal-flow">
         <div class="problem-grid problem-grid-three">
         <div class="problem-card"><span class="id">01</span><b>이동 비용</b><p>작업자가 보관 장소까지 직접 이동하면 작업 흐름이 끊깁니다.</p></div>
-        <div class="problem-card"><span class="id">02</span><b>공구 탐색</b><p>서랍을 열고 필요한 공구를 찾는 과정이 본 작업과 분리된 반복 업무가 됩니다.</p></div>
-        <div class="problem-card"><span class="id">03</span><b>반납 누락</b><p>사용 후 제자리에 돌아가지 않은 공구는 다음 작업과 재고 관리 문제로 이어집니다.</p></div>
+        <div class="problem-card"><span class="id">02</span><b>공구 탐색 비용</b><p>서랍을 열고 필요한 공구를 찾는 과정이 본 작업과 분리된 반복 업무가 됩니다.</p></div>
+        <div class="problem-card"><span class="id">03</span><b>반납 누락 비용</b><p>사용 후 제자리에 돌아가지 않은 공구는 다음 작업과 재고 관리 문제로 이어집니다.</p></div>
         </div>
         <div class="goal-arrow">↓</div>
         <div class="problem-card hot problem-goal-card"><span class="id">GOAL</span><b>MacGyvBot's GOAL</b><p>이동 로봇이 보관 서랍에서 공구를 꺼내 작업자에게 가져다주고, 사용 후 다시 보관합니다.</p></div>
@@ -165,7 +165,7 @@
         <div class="team-role-card"><span class="id">MANIPULATION</span><b>도건호</b><p>Drawer Flow / Simulation / QA</p></div>
         <div class="team-role-card"><span class="id">PERCEPTION</span><b>이건우</b><p>Vision Model Training</p></div>
         <div class="team-role-card"><span class="id">PM / PERCEPTION</span><b>이민형</b><p>Integration / Grasp Gesture Detection</p></div>
-        <div class="team-role-card"><span class="id">MANIPULATION</span><b>정채현</b><p>MoveIt / Safety</p></div>
+        <div class="team-role-card"><span class="id">MANIPULATION</span><b>정채현</b><p>MoveIt / Safety / Task Coordination</p></div>
       </div>
       </div>
     </section>
@@ -276,11 +276,12 @@
       <div class="kicker">Task Coordination / Design Choice</div>
       <h2>ROS2 Action vs. TaskStep Queue</h2>
       <div class="slide-body">
-      <div class="table">
-        <div class="row head"><div>구분</div><div>적합한 범위</div><div>MacGyvBot에서 필요한 제어</div></div>
-        <div class="row"><div>ROS2 Action</div><div>하나의 goal 실행, feedback, cancel</div><div>단일 motion이나 독립 동작에는 적합하지만 전체 bring/return 상태를 보존하기 어렵습니다.</div></div>
-        <div class="row"><div>Bring / Return</div><div>탐지, 서랍 조작, 파지, handoff, 복귀, 예외 복구가 연결된 workflow</div><div>현재 step, 남은 queue, perception 결과, recovery state를 함께 관리해야 합니다.</div></div>
-        <div class="row"><div>Task coordinator</div><div>TaskStep 단위의 중앙 실행 관리자</div><div>pause/resume/cancel, 동적 step 추가, drop recovery 이후 원래 작업 복귀를 일관되게 처리합니다.</div></div>
+      <div class="table task-comparison-table">
+        <div class="row head"><div>비교 축</div><div>ROS2 Action</div><div>TaskStep Queue</div></div>
+        <div class="row"><div>처리 단위</div><div>하나의 goal 실행, feedback, cancel에 적합</div><div>탐지, 서랍 조작, 파지, handoff, 복귀를 단계별로 연결</div></div>
+        <div class="row"><div>상태 보존</div><div>단일 동작 상태는 알기 쉽지만 bring/return 전체 진행 위치 보존은 제한적</div><div>현재 step, 남은 queue, target tool, perception 결과를 함께 보존</div></div>
+        <div class="row"><div>복구 처리</div><div>goal cancel 이후 다음 workflow를 별도로 재구성해야 함</div><div>pause/resume/cancel과 drop recovery 후 원래 작업 복귀를 같은 흐름에서 처리</div></div>
+        <div class="row"><div>적용 범위</div><div>개별 motion이나 독립 gripper 동작</div><div>MacGyvBot의 bring/return task 전체 orchestration</div></div>
       </div>
       </div>
     </section>
@@ -290,11 +291,12 @@
       <div class="kicker">Task Coordination / Pause Resume</div>
       <h2>queue 상태 처리</h2>
       <div class="slide-body">
-      <div class="table">
-        <div class="row head"><div>이벤트</div><div>처리 방식</div><div>보존되는 상태</div></div>
-        <div class="row"><div>pause</div><div>현재 MoveIt goal을 취소하고 실행 중이던 step을 suspended 상태로 전환</div><div>현재 step, 남은 queue, task context</div></div>
-        <div class="row"><div>resume</div><div>중단됐던 step부터 다시 실행하고 이후 queue를 계속 진행</div><div>bring/return 진행 위치와 목표 공구 context</div></div>
-        <div class="row"><div>cancel</div><div>queue를 정리하고 새로운 명령을 받을 준비 상태로 복귀</div><div>실행 중 goal cleanup과 GUI feedback</div></div>
+      <div class="table task-control-table">
+        <div class="row head"><div>이벤트</div><div>처리 방식</div><div>상태 변화</div><div>Home 이동</div></div>
+        <div class="row"><div>pause</div><div>현재 MoveIt goal을 취소하고 실행 중이던 step을 suspended 상태로 전환</div><div>현재 step, 남은 queue, task context 보존</div><div>없음</div></div>
+        <div class="row"><div>resume</div><div>중단됐던 step부터 다시 실행하고 이후 queue를 계속 진행</div><div>bring/return 진행 위치와 목표 공구 context 유지</div><div>없음</div></div>
+        <div class="row"><div>cancel</div><div>현재 작업과 queue만 정리하고 새 명령을 받을 준비 상태로 전환</div><div>실행 중 goal cleanup, task context 정리</div><div>없음</div></div>
+        <div class="row"><div>home</div><div>작업 명령과 별개로 로봇팔을 Home pose로 이동 요청</div><div>새 task를 만들지 않고 위치 복귀만 수행</div><div>수행</div></div>
         <!-- <div class="row"><div>drop recovery</div><div>기존 queue를 보존한 채 임시 recovery queue를 실행 후 원래 step으로 복귀</div><div>원래 작업 queue와 recovery 결과</div></div> -->
       </div>
       </div>
@@ -755,16 +757,9 @@
       </div>
     </section>
 
-    <section class="slide cover">
-      <img class="logo" src="assets/macgyvbot.png" alt="MacGyvBot logo" />
-      <div class="kicker">Closing</div>
-      <h1>MacGyvBot</h1>
-      <p class="lead">공구 요청과 반납을 하나의 closed loop로 만들고, 실제 로봇에서 깨진 가정을 task queue, perception evidence, safety recovery로 바꿨습니다.</p>
-      <div class="meta">
-        <span class="pill">What</span>
-        <span class="pill">How</span>
-        <span class="pill">Safety</span>
-        <span class="pill">Impact</span>
+    <section class="slide divider">
+      <div class="divider-inner demo-divider">
+        <h1 class="divider-title">시연영상</h1>
       </div>
     </section>
   </main>

--- a/MACGYVBOT-DECK/index.html
+++ b/MACGYVBOT-DECK/index.html
@@ -240,7 +240,7 @@
     <section class="slide divider">
       <div class="divider-inner">
         <div class="divider-code">SECTION 03</div>
-        <h1 class="divider-title">IMPLEMENT : TASK</h1>
+        <h1 class="divider-title">IMPLEMENT : <br>TASK Coordinator</h1></h1>
         <p class="divider-caption">Task coordinator와 TaskStep Queue</p>
       </div>
     </section>
@@ -365,7 +365,7 @@
           <div class="row success-bar" style="--rate: 90%; --bar-color: var(--green-2);"><div>서랍 내부</div><div>18 / 20</div><div>플라이어가 ArUco marker 등과 함께 인식되어 구분이 어려운 경우 발생</div></div>
           <div class="row success-bar" style="--rate: 95%; --bar-color: var(--green-2);"><div>서랍 내부 각도 변경</div><div>19 / 20</div><div>위와 동일한 원인으로 일부 오탐 또는 bbox 흔들림 발생</div></div>
           <div class="row success-bar warn" style="--rate: 55%; --bar-color: var(--yellow);"><div>그리퍼 파지 순간</div><div>11 / 20</div><div>공구와 가까워져 공구 일부가 가려지는 상황. <br> 드라이버는 비교적 안정적이나 랜치와 플라이어 인식률 저하</div></div>
-          <div class="row success-bar" style="--rate: 100%; --bar-color: var(--green-2);"><div>일반 작업 환경 동일 클래스 타 공구</div><div>20 / 20</div><div>open dataset 기반 학습으로 같은 class의 다른 공구에도 동작</div></div>
+          <div class="row success-bar" style="--rate: 100%; --bar-color: var(--green-2);"><div>동일 클래스 타 공구</div><div>20 / 20</div><div>open dataset 기반 학습으로 같은 class의 다른 공구에도 동작</div></div>
         </div>
       </div>
       </div>
@@ -381,7 +381,7 @@
           <div class="flow-step"><b>Tool bbox</b><span>YOLO가 찾은 공구 영역</span></div>
           <div class="flow-step"><b>Hand landmark</b><span>손 위치와 주요 관절 좌표</span></div>
           <div class="flow-step"><b>Distance / overlap</b><span>손과 공구의 근접도 계산</span></div>
-          <div class="flow-step hot"><b>Rule threshold</b><span>grasp 여부 판단</span></div>
+          <div class="flow-step"><b>Rule threshold</b><span>grasp 여부 판단</span></div>
         </div>
         <div class="failure-media-grid handoff-failure-compact">
           <figure class="failure-shot">
@@ -467,7 +467,7 @@
     <section class="slide">
       <div class="topbar"><span class="brand-mini"><img src="assets/macgyvbot.png" alt="" />MacGyvBot</span><span class="page-no"></span></div>
       <div class="kicker">Perception / Grasp Method / Decision</div>
-      <h2>Task-specific YOLO | SAM+Depth Mask | PCA</h2>
+      <h2>Final Method</h2>
       <div class="slide-body">
       <div class="decision-panel">
         <div class="proof-panel">
@@ -745,11 +745,11 @@
       <div class="slide-body">
       <div class="table future-work-table">
         <div class="row head"><div>구분</div><div>현재 한계</div><div>발전 방향</div></div>
-        <div class="row"><div>서랍 환경</div><div>서랍 위치와 손잡이 위치가 고정되어 있어 환경 변경 시 재설정이 필요</div><div>서랍과 손잡이를 인식해 open/close target을 동적으로 생성</div></div>
-        <div class="row"><div>공구 배치</div><div>서랍과 공구 위치가 1:1로 매핑되어 있어 다른 칸에 놓이면 대응이 어려움</div><div>서랍 내부를 인식하고 공구 위치를 실시간으로 갱신하는 inventory map 구성</div></div>
-        <div class="row"><div>공구 인식</div><div>grasp point가 YOLO 학습 class와 bbox 품질에 의존해 새 공구 투입 시 재학습 필요</div><div>open-vocabulary detection과 VLM affordance 판단으로 새 공구 일반화</div></div>
-        <div class="row"><div>Task planning</div><div>현재는 구현된 sequence 중심으로 동작해 상태 변화에 따른 자율 선택이 제한적</div><div>LLM이 사용 가능한 interface와 상태/이미지 해석 결과를 보고 필요한 움직임 수행</div></div>
-        <div class="row"><div>정교한 조작</div><div>서랍에 잘 넣고, 잘 잡고, 안정적으로 빼는 판단은 규칙 기반으로 한계가 있음</div><div>VLM과 결합해 넣기/잡기/빼기 affordance를 평가하고 재시도 전략 생성</div></div>
+        <div class="row"><div>유동적 서랍 환경</div><div>서랍 위치와 손잡이 위치가 고정되어 있어 환경 변경 시 재설정이 필요</div><div>서랍과 손잡이를 인식해 open/close target을 동적으로 생성</div></div>
+        <div class="row"><div>다양한 공구 배치</div><div>서랍과 공구 위치가 1:1로 매핑되어 있어 다른 칸에 놓이면 대응이 어려움</div><div>서랍 내부를 인식하고 공구 위치를 실시간으로 갱신하는 inventory map 구성</div></div>
+        <div class="row"><div>다양한 공구 인식</div><div>grasp point가 YOLO 학습 class와 bbox 품질에 의존해 새 공구 투입 시 재학습 필요</div><div>open-vocabulary detection과 VLM affordance 판단으로 새 공구 일반화</div></div>
+        <div class="row"><div>유동적 Task planning</div><div>현재는 구현된 sequence 중심으로 동작해 상태 변화에 따른 자율 선택이 제한적</div><div>LLM이 사용 가능한 interface와 상태/이미지 해석 결과를 보고 필요한 움직임 수행</div></div>
+        <div class="row"><div>정교한 잡는 자세 조작</div><div>서랍에 잘 넣고, 잘 잡고, 안정적으로 빼는 판단은 규칙 기반으로 한계가 있음</div><div>VLM과 결합해 넣기/잡기/빼기 affordance를 평가하고 재시도 전략 생성</div></div>
       </div>
       </div>
     </section>

--- a/MACGYVBOT-DECK/index.html
+++ b/MACGYVBOT-DECK/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>MacGyvBot Troubleshooting Deck</title>
-  <link rel="stylesheet" href="styles/deck.css?v=20260617-operator-contain" />
+  <link rel="stylesheet" href="styles/deck.css?v=20260617-section-flow" />
 </head>
 <body>
   <main class="deck" id="deck">
@@ -72,11 +72,14 @@
       <div class="kicker">Problem / Why Robot</div>
       <h2>문제 정의: Tool Flow Interruption</h2>
       <div class="slide-body">
-      <div class="problem-grid">
+      <div class="problem-goal-flow">
+        <div class="problem-grid problem-grid-three">
         <div class="problem-card"><span class="id">01</span><b>이동 비용</b><p>작업자가 보관 장소까지 직접 이동하면 작업 흐름이 끊깁니다.</p></div>
         <div class="problem-card"><span class="id">02</span><b>공구 탐색</b><p>서랍을 열고 필요한 공구를 찾는 과정이 본 작업과 분리된 반복 업무가 됩니다.</p></div>
         <div class="problem-card"><span class="id">03</span><b>반납 누락</b><p>사용 후 제자리에 돌아가지 않은 공구는 다음 작업과 재고 관리 문제로 이어집니다.</p></div>
-        <div class="problem-card hot"><span class="id">GOAL</span><b>MacGyvBot's GOAL</b><p>이동 로봇이 보관 서랍에서 공구를 꺼내 작업자에게 가져다주고, 사용 후 다시 보관합니다.</p></div>
+        </div>
+        <div class="goal-arrow">↓</div>
+        <div class="problem-card hot problem-goal-card"><span class="id">GOAL</span><b>MacGyvBot's GOAL</b><p>이동 로봇이 보관 서랍에서 공구를 꺼내 작업자에게 가져다주고, 사용 후 다시 보관합니다.</p></div>
       </div>
       </div>
     </section>
@@ -124,14 +127,14 @@
       <div class="slide-body">
       <div class="system-map compact" style="--cols: 5; margin-top: 24px;">
         <div class="system-node"><span class="id">CMD</span><b>Command</b><span>LLM/parser, STT/TTS, GUI command</span></div>
-        <div class="system-node"><span class="id">TASK</span><b>Task Queue</b><span>bring/return sequence, pause/resume</span></div>
+        <div class="system-node"><span class="id">TASK</span><b>Coordinator</b><span>bring/return flow, pause/resume</span></div>
         <div class="system-node"><span class="id">VISION</span><b>Perception</b><span>YOLO, mask, handoff, PCA grasp</span></div>
         <div class="system-node"><span class="id">MOTION</span><b>Manipulation</b><span>MoveIt, RG2, drawer motion</span></div>
         <div class="system-node"><span class="id">SAFE</span><b>Safety</b><span>collision scene, drop recovery</span></div>
       </div>
       <div class="signal-stack compact rail" style="margin-top: 14px;">
-        <div class="signal-row"><span class="id">PKG</span><b>Package boundary</b><span>task, command, perception, manipulation이 ROS topic/service로 연결됩니다.</span><span class="state">ROS</span></div>
-        <div class="signal-row"><span class="id">TOPICS</span><b>Typed contracts</b><span>/task_request, /task_control, /human_grasped_tool, /sam_yaw, /tool_drop_detected</span><span class="state">ROS</span></div>
+        <div class="signal-row"><span class="id">ROLE</span><b>역할 분리</b><span>명령, 작업, 인식, 조작이 각자 맡은 일만 수행합니다.</span><span class="state">ROS</span></div>
+        <div class="signal-row"><span class="id">LINK</span><b>메시지 연결</b><span>패키지끼리는 직접 호출하지 않고 topic/service로 연결됩니다.</span><span class="state">API</span></div>
       </div>
       </div>
     </section>
@@ -170,7 +173,7 @@
     <section class="slide divider">
       <div class="divider-inner">
         <div class="divider-code">SECTION 03</div>
-        <h1 class="divider-title">COMMAND</h1>
+        <h1 class="divider-title">IMPLEMENT : COMMAND</h1>
         <p class="divider-caption">자연어 요청을 안정적인 robot task intent로 변환</p>
       </div>
     </section>
@@ -239,9 +242,9 @@
 
     <section class="slide divider">
       <div class="divider-inner">
-        <div class="divider-code">SECTION 04</div>
-        <h1 class="divider-title">TASK COORDINATION</h1>
-        <p class="divider-caption">TaskStep Queue</p>
+        <div class="divider-code">SECTION 03</div>
+        <h1 class="divider-title">IMPLEMENT : TASK</h1>
+        <p class="divider-caption">Task coordinator와 TaskStep Queue</p>
       </div>
     </section>
 
@@ -299,8 +302,8 @@
 
     <section class="slide divider">
       <div class="divider-inner">
-        <div class="divider-code">SECTION 05</div>
-        <h1 class="divider-title">PERCEPTION</h1>
+        <div class="divider-code">SECTION 03</div>
+        <h1 class="divider-title">IMPLEMENT : PERCEPTION</h1>
         <p class="divider-caption">Calibration, YOLO, Handoff, PCA</p>
       </div>
     </section>
@@ -535,8 +538,8 @@
 
     <section class="slide divider">
       <div class="divider-inner">
-        <div class="divider-code">SECTION 06</div>
-        <h1 class="divider-title">MANIPULATION</h1>
+        <div class="divider-code">SECTION 03</div>
+        <h1 class="divider-title">IMPLEMENT : MANIPULATION</h1>
         <p class="divider-caption">공구를 꺼내고 전달하고 다시 서랍에 보관하는 실행 계층</p>
       </div>
     </section>
@@ -613,7 +616,7 @@
 
     <section class="slide divider">
       <div class="divider-inner">
-        <div class="divider-code">SECTION 07</div>
+        <div class="divider-code">SECTION 04</div>
         <h1 class="divider-title">SAFETY</h1>
         <p class="divider-caption">collision scene, tool drop detection, recovery flow</p>
       </div>
@@ -686,7 +689,7 @@
 
     <section class="slide divider">
       <div class="divider-inner">
-        <div class="divider-code">SECTION 08</div>
+        <div class="divider-code">SECTION 04</div>
         <h1 class="divider-title">SIMULATION</h1>
         <p class="divider-caption">실제 로봇 투입 전 sequence와 collision risk를 검증하는 환경</p>
       </div>
@@ -708,7 +711,7 @@
 
     <section class="slide divider">
       <div class="divider-inner">
-        <div class="divider-code">SECTION 09</div>
+        <div class="divider-code">SECTION 05</div>
         <h1 class="divider-title">IMPACT</h1>
         <p class="divider-caption">작업자가 공구 때문에 흐름을 끊지 않도록 만드는 로봇 task layer</p>
       </div>

--- a/MACGYVBOT-DECK/index.html
+++ b/MACGYVBOT-DECK/index.html
@@ -755,11 +755,12 @@
     </section>
 
     <section class="slide divider">
-      <div class="divider-inner demo-divider">
-        <h1 class="divider-title">시연영상</h1>
+      <div class="divider-inner">
+        <div class="divider-code">SECTION 06</div>
+        <h1 class="divider-title">시연</h1>
+        <p class="divider-caption">https://github.com/MacGyvBot</p>
       </div>
     </section>
-  </main>
 
   <div class="nav" aria-label="slide navigation">
     <button type="button" id="prev">Prev</button>

--- a/MACGYVBOT-DECK/index.html
+++ b/MACGYVBOT-DECK/index.html
@@ -29,7 +29,7 @@
           <h2>문제 정의에서 설계, 구현, 검증 순서로 설명합니다</h2>
         </div>
         <div class="arc-grid intro-stack toc-stack" style="grid-template-columns: 1fr; gap: 10px;">
-          <div class="flow-step hot"><b>1. MacGyvBot이 해결하고자 하는 문제</b><span>공구 요청과 반납 흐름</span></div>
+          <div class="flow-step"><b>1. MacGyvBot이 해결하고자 하는 문제</b><span>공구 요청과 반납 흐름</span></div>
           <div class="flow-step"><b>2. 시스템 디자인</b><span>ROS 2 task architecture</span></div>
           <div class="flow-step"><b>3. 구현</b><span>Command, Task, Perception, Manipulation</span></div>
           <div class="flow-step"><b>4. Safety / Simulation</b><span>recovery와 Isaac Sim 검증</span></div>
@@ -123,11 +123,11 @@
     <section class="slide">
       <div class="topbar"><span class="brand-mini"><img src="assets/macgyvbot.png" alt="" />MacGyvBot</span><span class="page-no"></span></div>
       <div class="kicker">System Design / Architecture</div>
-      <h2>Command-to-Task 기반 ROS 2 계층형 아키텍처</h2>
+      <h2>Service 아키텍처</h2>
       <div class="slide-body">
       <div class="system-map compact" style="--cols: 5; margin-top: 24px;">
         <div class="system-node"><span class="id">CMD</span><b>Command</b><span>LLM/parser, STT/TTS, GUI command</span></div>
-        <div class="system-node"><span class="id">TASK</span><b>Coordinator</b><span>bring/return flow, pause/resume</span></div>
+        <div class="system-node"><span class="id">TASK</span><b>Task Coordinator</b><span>bring/return sequence, pause/resume</span></div>
         <div class="system-node"><span class="id">VISION</span><b>Perception</b><span>YOLO, mask, handoff, PCA grasp</span></div>
         <div class="system-node"><span class="id">MOTION</span><b>Manipulation</b><span>MoveIt, RG2, drawer motion</span></div>
         <div class="system-node"><span class="id">SAFE</span><b>Safety</b><span>collision scene, drop recovery</span></div>
@@ -142,12 +142,12 @@
     <section class="slide">
       <div class="topbar"><span class="brand-mini"><img src="assets/macgyvbot.png" alt="" />MacGyvBot</span><span class="page-no"></span></div>
       <div class="kicker">Development Flow</div>
-      <h2>MILESTONE</h2>
+      <h2>Project Development Process</h2>
       <div class="slide-body">
       <div class="timeline milestone-rail">
-        <div class="timebox"><div class="phase">05.04</div><h3>Pipeline Skeleton</h3><p>Pick and Place, Topic Command</p></div>
+        <div class="timebox"><div class="phase">05.04</div><h3>Base Pipeline</h3><p>Pick and Place, Topic Command</p></div>
         <div class="timebox"><div class="phase">05.06</div><h3>Pick & Handover</h3><p>GUI Prototype, Pick and Handover to User</p></div>
-        <div class="timebox"><div class="phase">05.13</div><h3>Retrieve Tool</h3><p>Return Tool From User, Place Temporary Space</p></div>
+        <div class="timebox"><div class="phase">05.13</div><h3>Return Tool</h3><p>Return Tool From User, Place Temporary Space</p></div>
         <div class="timebox"><div class="phase">05.20</div><h3>Store in Drawer</h3><p>Open Close Drawer, Place Tool in Drawer</p></div>
         <div class="timebox"><div class="phase">06.05 / 06.12</div><h3>Advanced <br> & Safety</h3><p>Enhanced PCA, SAM, YOLO, Safety, Recovery, Exception Handling</p></div>
       </div>
@@ -157,7 +157,7 @@
     <section class="slide">
       <div class="topbar"><span class="brand-mini"><img src="assets/macgyvbot.png" alt="" />MacGyvBot</span><span class="page-no"></span></div>
       <div class="kicker">Team / Role</div>
-      <h2>협업 기반 업무 분장</h2>
+      <h2>팀원별 담당 영역</h2>
       <div class="slide-body">
       <div class="team-role-grid">
         <div class="team-role-card"><span class="id">PERCEPTION</span><b>김성윤</b><p>Tool Grasp Method</p></div>
@@ -274,7 +274,7 @@
     <section class="slide">
       <div class="topbar"><span class="brand-mini"><img src="assets/macgyvbot.png" alt="" />MacGyvBot</span><span class="page-no"></span></div>
       <div class="kicker">Task Coordination / Design Choice</div>
-      <h2>ROS2 Action VS TaskStep Queue</h2>
+      <h2>ROS2 Action vs. TaskStep Queue</h2>
       <div class="slide-body">
       <div class="table">
         <div class="row head"><div>구분</div><div>적합한 범위</div><div>MacGyvBot에서 필요한 제어</div></div>
@@ -408,7 +408,7 @@
           <div class="flow-step"><b>YOLO bbox ROI</b><span>bbox를 clamp하고 crop 기준으로 사용</span></div>
           <div class="flow-step"><b>SAM foreground</b><span>bbox 안에서 물체처럼 보이는 mask 생성</span></div>
           <div class="flow-step"><b>Foreground depth</b><span>mask 안 가까운 depth cluster 선택</span></div>
-          <div class="flow-step hot"><b>Refine + morphology</b><span>depth tolerance로 남기고 구멍 보정</span></div>
+          <div class="flow-step"><b>Refine + morphology</b><span>depth tolerance로 남기고 구멍 보정</span></div>
         </div>
         <figure class="wide-media-shot compact">
           <img src="assets/perception/handoff/sam_depth_mask.gif?v=loop" alt="SAM and depth mask generation result" />
@@ -568,7 +568,7 @@
         <div class="problem-card"><span class="id">ASSUMPTION</span><b>서랍 위치 고정</b><p>현실의 공구 서랍은 작업장 안에서 자주 이동하지 않으므로, 기준 좌표를 고정값으로 관리할 수 있습니다.</p></div>
         <div class="problem-card"><span class="id">CONFIG</span><b>좌표 하드코딩</b><p>서랍 handle, safe z, approach depth를 설정값으로 두어 반복 가능한 open, pick, place sequence를 구성했습니다.</p></div>
         <div class="problem-card"><span class="id">BENEFIT</span><b>반복성 확보</b><p>매번 drawer pose를 새로 추정하지 않아도 같은 서랍에서 안정적인 motion target을 재사용할 수 있습니다.</p></div>
-        <div class="problem-card hot"><span class="id">LIMIT</span><b>변경 시 보정 필요</b><p>서랍 위치가 바뀌는 환경에서는 고정 좌표만으로 부족하므로 marker 기반 기준점이 필요합니다.</p></div>
+        <div class="problem-card"><span class="id">LIMIT</span><b>변경 시 보정 필요</b><p>서랍 위치가 바뀌는 환경에서는 고정 좌표만으로 부족하므로 marker 기반 기준점이 필요합니다.</p></div>
       </div>
       </div>
     </section>

--- a/MACGYVBOT-DECK/styles/common.css
+++ b/MACGYVBOT-DECK/styles/common.css
@@ -1678,6 +1678,44 @@ ul.clean-list li::before {
 .row:not(.head) > div:nth-child(1) { font-weight: 800; }
 .row:not(.head) > div { color: #404850; }
 
+.task-comparison-table .row {
+  grid-template-columns: .85fr 1.35fr 1.55fr;
+}
+
+.task-comparison-table .row > div {
+  padding: 15px 18px;
+  font-size: 16px;
+}
+
+.task-comparison-table .row.head > div:nth-child(2),
+.task-comparison-table .row.head > div:nth-child(3) {
+  text-align: center;
+}
+
+.task-control-table .row {
+  grid-template-columns: .72fr 1.52fr 1.22fr .68fr;
+}
+
+.task-control-table .row > div {
+  padding: 14px 15px;
+  font-size: 15px;
+  line-height: 1.36;
+}
+
+.task-control-table .row > div:last-child {
+  text-align: center;
+  font-weight: 800;
+}
+
+.demo-divider {
+  justify-items: center;
+  text-align: center;
+}
+
+.demo-divider .divider-title {
+  font-size: clamp(74px, 8vw, 118px);
+}
+
 .yolo-success-layout {
   display: grid;
   grid-template-columns: minmax(0, .38fr) minmax(0, .62fr);

--- a/MACGYVBOT-DECK/styles/common.css
+++ b/MACGYVBOT-DECK/styles/common.css
@@ -263,6 +263,38 @@ h3 {
   gap: 16px;
 }
 
+.problem-goal-flow {
+  display: grid;
+  gap: 12px;
+  align-items: center;
+}
+
+.problem-grid-three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.problem-goal-flow .problem-card {
+  min-height: 184px;
+}
+
+.goal-arrow {
+  justify-self: center;
+  width: 52px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  color: var(--green-2);
+  font-size: 34px;
+  line-height: 1;
+  font-weight: 900;
+}
+
+.problem-goal-card {
+  justify-self: center;
+  width: min(560px, 100%);
+  min-height: 142px !important;
+}
+
 .problem-card {
   min-height: 250px;
   display: grid;


### PR DESCRIPTION
## 📌 변경 내용 요약

Presentation deck section transition pages now match the five-item table of contents and use consistent implementation labels. The problem slide layout was adjusted to emphasize the project goal below the three problem cards, and the system architecture slide copy was simplified for readability.

## 🧩 변경 유형

- [ ] 버그 수정
- [ ] 신규 기능 추가
- [ ] 리팩토링
- [x] 문서 수정
- [ ] 모델/실험 코드 변경
- [ ] 데이터셋/라벨 변경
- [ ] ROS 2 패키지 변경
- [ ] 설정 파일 변경
- [ ] 안전 관련 변경
- [ ] 기타:

## 🔗 관련 이슈

Related #2

## ✅ 테스트 내용

- [x] 로컬 실행 확인
- [ ] ROS 2 노드 실행 확인
- [ ] 카메라 입력 확인
- [ ] 모델 추론 확인
- [ ] 로봇팔 이동 확인
- [ ] 그리퍼 동작 확인
- [ ] 서랍 개폐 확인
- [ ] 시뮬레이션 확인
- [x] 문서 링크 확인
- [ ] 해당 없음

## 📋 테스트 결과 로그

```text
git diff --check
static site smoke passed

Generated local screenshots for deck pages:
- slide 5: goal card layout
- slide 8: coordinator architecture copy
- slide 15: IMPLEMENT : TASK divider
- slide 31/34: later slide render checks
```

## 🧾 체크리스트

- [x] 코드가 정상 실행된다.
- [x] 불필요한 파일이 포함되지 않았다.
- [x] 큰 모델 파일/데이터셋이 포함되지 않았다.
- [x] 필요한 문서가 업데이트되었다.
- [x] 설정값 하드코딩 여부를 확인했다.
- [x] 안전 관련 변경을 검토했다.

## 👀 리뷰어가 확인해야 할 부분

- Section divider labels now use only `SECTION 01` through `SECTION 05` to match the table of contents.
- Implementation sub-sections are shown as `IMPLEMENT : COMMAND/TASK/PERCEPTION/MANIPULATION`.
- Problem slide goal card is visually separated below the three problem cards.
- Architecture slide wording is simplified while preserving the Coordinator terminology.

## 📎 추가 설명

This PR changes only the presentation deck HTML/CSS. No ROS runtime code or robot behavior is changed.
